### PR TITLE
Add a basic .gitattributes file to the project root, fixes #43

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Article: https://help.github.com/articles/dealing-with-line-endings/
+# Helpful examples: https://github.com/alexkaratarakis/gitattributes
+
+# every text should use eol lf - basically the same as core.autocrlf=false
+* -text eol=lf
+
+*.png binary
+*.zip binary


### PR DESCRIPTION
I just went ahead and created a PR with a basic `.gitattributes` file starting point for a discussion. I've oriented towards the one we are using on the DDEV repo (https://github.com/ddev/ddev/blob/main/.gitattributes). It simply sets every textfile to an  EOL of `lf`. For binaries i only used the suffixes png and zip used in the page-script-5 repo. if more details should be unified for text files the one used in drupal could be a good inspiration: https://git.drupalcode.org/project/drupal/-/blob/11.x/.gitattributes?ref_type=heads . asi'Ve said just wanted to start the discussion in regard of a .gitattributes file cuz every PR i did so far had hundreds of changes lines. 