### PR TITLE
fix a few cspell errors

### DIFF
--- a/src/accName.js
+++ b/src/accName.js
@@ -22,11 +22,11 @@ export {
 };
 
 /**
- *   @fuction getAccessibleName
+ *   @function getAccessibleName
  *
  *   @desc Returns the accessible name for an heading or landmark
  *
- *   @paramn {Object}   dom      - Document of the current element
+ *   @param  {Object}   dom      - Document of the current element
  *   @param  {node}     element  - DOM element node for either a heading or
  *                               landmark
  *   @param  {Boolean}  fromContent  - if true will compute name from content

--- a/src/highlightElement.js
+++ b/src/highlightElement.js
@@ -79,7 +79,7 @@ export default class HighlightElement {
                             'Region is hidden';
 
     this.msgElementIsHidden = typeof config.msgElementIsHidden === 'string' ?
-                            config.msgElemenIsHidden :
+                            config.msgElementIsHidden :
                             'Element is hidden';
 
     [this.borderWidth, this.shadowWidth, this.offset, this.fontSize] = getHighlightInfo(config.highlightBorderSize);
@@ -95,7 +95,7 @@ export default class HighlightElement {
    *   @param {Object}  elem            : DOM node of element to highlight
    *   @param {String}  highlightTarget : value of highlight target
    *   @param {String}  info            : Information about target
-   *   @param {Boolean} force           : If true override isRduced
+   *   @param {Boolean} force           : If true override isReduced
    */
 
   highlight(elem, highlightTarget='instant', info='', force=false) {
@@ -114,7 +114,7 @@ export default class HighlightElement {
 
       if (this.isElementHidden(elem)) {
         // If element is hidden make hidden element message visible
-        // and use for highlighing
+        // and use for highlighting
         this.hiddenElem.textContent = this.getHiddenMessage(elem);
         this.hiddenElem.style.display = 'block';
 
@@ -288,7 +288,7 @@ export default class HighlightElement {
    *   @method isElementInViewport
    *
    *   @desc  Returns true if element is already visible in view port,
-   *          otheriwse false
+   *          otherwise false
    *
    *   @param {Object} elem : DOM node of element to highlight
    *
@@ -333,7 +333,7 @@ export default class HighlightElement {
    *   @method isElementHeightLarge
    *
    *   @desc  Returns true if element client height is larger than clientHeight,
-   *          otheriwse false
+   *          otherwise false
    *
    *   @param {Object} elem : DOM node of element to highlight
    *

--- a/src/landmarksHeadings.js
+++ b/src/landmarksHeadings.js
@@ -132,7 +132,7 @@ function isSkipableElement(element) {
 /*
  *   @function isCustomElement
  *
- *   @desc  Reuturns true if the element is a custom element, otherwise
+ *   @desc  Returns true if the element is a custom element, otherwise
  *          false
  *
  *   @param  {Object}  element  - DOM element node
@@ -146,7 +146,7 @@ function isCustomElement(element) {
 /*
  *   @function sSlotElement
  *
- *   @desc  Reuturns true if the element is a slot element, otherwise
+ *   @desc  Returns true if the element is a slot element, otherwise
  *          false
  *
  *   @param  {Object}  element  - DOM element node
@@ -164,9 +164,9 @@ function isSlotElement(node) {
 *         elements with default landmark roles or is the descendant
 *         of an element with a defined landmark role
 *
-*   @param  {Object}  node  - Element node from a berowser DOM
+*   @param  {Object}  node  - Element node from a browser DOM
 * 
-*   @reutrn {Boolean} Returns true if top level landmark, otherwise false
+*   @return {Boolean} Returns true if top level landmark, otherwise false
 */
 
 function isTopLevel (node) {
@@ -396,9 +396,9 @@ function findVisibleElement (startingNode, tagNames) {
 /*
  *   @function skipToElement
  *
- *   @desc Moves focus to the element identified by the memu item
+ *   @desc Moves focus to the element identified by the menu item
  *
- *   @param {Object}  menutim  -  DOM element in the menu identifying the target element.
+ *   @param {Object}  menuitem  -  DOM element in the menu identifying the target element.
  */ 
 function skipToElement(menuitem) {
 
@@ -475,11 +475,11 @@ function setItemFocus(elem, isLandmark, isSearch, isNav) {
  *   @function getHeadingTargets
  *
  *   @desc  Returns an array of heading tag names to include in menu
- *          NOTE: It uses "includes" method to maximimze compatibility with
+ *          NOTE: It uses "includes" method to maximize compatibility with
  *          previous versions of SkipTo which used CSS selectors for 
  *          identifying targets.
  *
- *   @param {String}  targets  -  A space with the heading tags to inclucde
+ *   @param {String}  targets  -  A space with the heading tags to include
  *
  *   @returns {Array}  Array of heading element tag names to include in menu
  */ 
@@ -496,7 +496,7 @@ function getHeadingTargets(targets) {
 /*
  *   @function isMain
  *
- *   @desc  Returns true if the element is a main landamrk
+ *   @desc  Returns true if the element is a main landmark
  *
  *   @param  {Object}  element  -  DOM element node
  *
@@ -515,9 +515,9 @@ function isMain (element) {
  *   @function queryDOMForLandmarksAndHeadings
  *
  *   @desc  Recursive function to return two arrays, one an array of the DOM element nodes for 
- *          landmarks and the other an array of DOM element ndoes for headings  
+ *          landmarks and the other an array of DOM element nodes for headings  
  *
- *   @param  {Array}   landamrkTargets  -  An array of strings representing landmark regions
+ *   @param  {Array}   landmarkTargets  -  An array of strings representing landmark regions
  *   @param  {Array}   headingTargets  -  An array of strings representing headings
  *   @param  {String}  skiptoId        -  An array of strings representing headings
  *
@@ -737,8 +737,8 @@ function getHeadings (config, headings) {
  * @desc Localizes a landmark name and adds accessible name if defined
  *
  * @param {Object} config  - Object with configuration information
- * @param {String} tagName - String with landamrk and/or tag names
- * @param {String} AccName - Accessible name for therlandmark, maybe an empty string
+ * @param {String} tagName - String with landmark and/or tag names
+ * @param {String} AccName - Accessible name for the landmark, maybe an empty string
  *
  * @returns {String}  A localized string for a landmark name
  */

--- a/src/namefrom.js
+++ b/src/namefrom.js
@@ -24,7 +24,7 @@ debug.flag = false;
 *   @function nameFromAttribute
 *
 *   @desc  If defined, returns the value of an attribute,
-*          otheriwse the empty string
+*          otherwise the empty string
 *
 *   @param {Object}  element    - DOM element node
 *   @param {String}  attribute  - String identifying the attribute
@@ -97,7 +97,7 @@ function isDisplayNone (node) {
     }
 
     // aria-hidden attribute with the value "true" is an same as 
-    // setting the hidden attribute for name calcuation
+    // setting the hidden attribute for name calculation
     if (node.hasAttribute('aria-hidden')) {
       if (node.getAttribute('aria-hidden').toLowerCase()  === 'true') {
         return true;
@@ -118,7 +118,7 @@ function isDisplayNone (node) {
 /*
 *   @function isVisibilityHidden 
 *   
-*   @desc Returns true if the node (or it's parrent) has the CSS visibility 
+*   @desc Returns true if the node (or it's parent) has the CSS visibility 
 *         property set to "hidden" or "collapse", otherwise false
 *
 *   @param  {Object}   node  -  DOM node
@@ -152,7 +152,7 @@ function isVisibilityHidden(node) {
 *   
 *   @desc Returns true if the node has the aria-hidden property set to
 *         "false", otherwise false.  
-*         NOTE: This function is important in the accessible namce 
+*         NOTE: This function is important in the accessible name 
 *               calculation, since content hidden with a CSS technique 
 *               can be included in the accessible name calculation when 
 *               aria-hidden is set to false
@@ -277,7 +277,7 @@ function getNodeContents (node) {
 *          the element could have an 'alt' attribute,
 *          otherwise false.
 * 
-*   @param  {Object}  element  - DOM eleemnt node
+*   @param  {Object}  element  - DOM element node
 *
 *   @return {Boolean}  see @desc
 */

--- a/src/skiptoContent.js
+++ b/src/skiptoContent.js
@@ -409,7 +409,7 @@ export default class SkipToContent592 extends HTMLElement {
   /*
    * @method supportShortcuts
    *
-   * @desc  Set suuportShortcuts configuration property
+   * @desc  Set supportShortcuts configuration property
    *
    * @param  {Boolean}  value - If true support keyboard shortcuts, otherwise disable
    */
@@ -433,7 +433,7 @@ export default class SkipToContent592 extends HTMLElement {
    *   @param {Object}  elem            : DOM node of element to highlight
    *   @param {String}  highlightTarget : value of highlight target
    *   @param {String}  info            : Information about target
-   *   @param {Boolean} force           : If true override isRduced
+   *   @param {Boolean} force           : If true override isReduced
    */
 
   highlight(elem, highlightTarget='instant', info='', force=false) {

--- a/src/skiptoMenuButton.js
+++ b/src/skiptoMenuButton.js
@@ -112,7 +112,7 @@ templateMenuButton.innerHTML = `
  * @desc Constructor for creating a button to open a menu of headings and landmarks on 
  *       a web page
  *
- * @param {Object}  skipToContentElem  -  The skip-to-content objecy
+ * @param {Object}  skipToContentElem  -  The skip-to-content object
  * 
  * @returns {Object}  DOM element node that is the container for the button and the menu
  */
@@ -270,7 +270,7 @@ export default class SkiptoMenuButton {
      *   @param {Object}  elem            : DOM node of element to highlight
      *   @param {String}  scrollBehavior  : value of highlight target
      *   @param {String}  info            : Information about target
-     *   @param {Boolean} force           : If true override isRduced
+     *   @param {Boolean} force           : If true override isReduced
      */
 
     highlight(elem, scrollBehavior='instant', info='', force=false) {
@@ -435,7 +435,7 @@ export default class SkiptoMenuButton {
     /*
      * @method updateKeyboardShortCuts
      *
-     * @desc Updates the keyboard short cuts for the curent menu items
+     * @desc Updates the keyboard short cuts for the current menu items
      */
     updateKeyboardShortCuts () {
       let mi;
@@ -548,7 +548,7 @@ export default class SkiptoMenuButton {
      * 
      * @param  {Object}  groupNode       -  DOM element node for the menu group
      * @param  {Array}   menuitems       -  Array of objects with menu item information
-     * @param  {String}  msgNoItesmFound -  Message to render if there are no menu items
+     * @param  {String}  msgNoItemsFound -  Message to render if there are no menu items
      */
     renderMenuitemsToGroup(groupNode, menuitems, msgNoItemsFound) {
       // remove all child nodes
@@ -857,7 +857,7 @@ export default class SkiptoMenuButton {
     /*
      * @method closePopup
      *
-     * @desc Closes the memu of landmark regions and headings
+     * @desc Closes the menu of landmark regions and headings
      */
     closePopup(moveFocusToButton=false) {
       if (this.isOpen()) {
@@ -970,7 +970,7 @@ export default class SkiptoMenuButton {
     /*
      * @method setDisplayOption
      *
-     * @desc Set display option for button visibility wehn it does not
+     * @desc Set display option for button visibility when it does not
      *       have focus
      *
      * @param  {Object}  elem  - DOM element to update style

--- a/src/style.js
+++ b/src/style.js
@@ -766,7 +766,7 @@ function getTheme(colorTheme) {
           pathnameMatch = '';
         }
         else {
-          // if the same hostname is used in another theme, set the hostnameFlas in case the pathname
+          // if the same hostname is used in another theme, set the hostnameFlag in case the pathname
           // matches
           if (colorThemes[hostnameMatch].hostnameSelector.length === hostnameSelector.length) {
             hostnameFlag = true;
@@ -887,7 +887,7 @@ function updateCSS (containerNode, config, useURLTheme=false) {
   updateStyle(containerNode, '--skipto-button-background-color',      config.buttonBackgroundColor,     theme.buttonBackgroundColor,     d.buttonBackgroundColor);
   updateStyle(containerNode, '--skipto-button-background-dark-color', config.buttonBackgroundDarkColor, theme.buttonBackgroundDarkColor, d.buttonBackgroundDarkColor);
 
-  updateStyle(containerNode, '--skipto-dialog-text-color',                  config.dialogTextColor,                theme.dialogTextColorr,               d.dialogTextColor);
+  updateStyle(containerNode, '--skipto-dialog-text-color',                  config.dialogTextColor,                theme.dialogTextColor,                d.dialogTextColor);
   updateStyle(containerNode, '--skipto-dialog-text-dark-color',             config.dialogTextDarkColor,            theme.dialogTextDarkColor,            d.dialogTextDarkColor);
   updateStyle(containerNode, '--skipto-dialog-background-color',            config.dialogBackgroundColor,          theme.dialogBackgroundColor,          d.dialogBackgroundColor);
   updateStyle(containerNode, '--skipto-dialog-background-dark-color',       config.dialogBackgroundDarkColor,      theme.dialogBackgroundDarkColor,      d.dialogBackgroundDarkColor);

--- a/src/utils.js
+++ b/src/utils.js
@@ -107,7 +107,7 @@ function normalize (s) {
 }
 
 /**
- * @fuction isNotEmptyString
+ * @function isNotEmptyString
  *
  * @desc Returns true if the string has content, otherwise false
  *
@@ -118,7 +118,7 @@ function isNotEmptyString (str) {
 }
 
 /**
- * @fuction isEmptyString
+ * @function isEmptyString
  *
  * @desc Returns true if the string is empty, otherwise false
  *
@@ -129,7 +129,7 @@ function isEmptyString (str) {
 }
 
 /**
- * @fuction normalizeName
+ * @function normalizeName
  *
  * @desc Removes extra spaces, linefeeds and cariage returns from a string
  *
@@ -143,11 +143,11 @@ function normalizeName (name) {
 }
 
 /**
- * @fuction isVisible
+ * @function isVisible
  *
  * @desc Returns true if the element is visible in the graphical rendering 
  *
- * @param {node}  elem  - DOM element node of a labelable element
+ * @param {node}  elem  - DOM element node of a labeled element
  */
 function isVisible (element) {
 
@@ -184,12 +184,12 @@ function isVisible (element) {
 }
 
 /**
- * @fuction isSmallOrOffScreen
+ * @function isSmallOrOffScreen
  *
  * @desc Returns true if the element is not very high or wide, or is
  *       positioned outside the graphical rendering
  *
- * @param {node}  elementNode  - DOM element node of a labelable element
+ * @param {node}  elementNode  - DOM element node of a labeled element
  */
 function isSmallOrOffScreen(elementNode) {
 


### PR DESCRIPTION
cspell noticed a few typos. i went ahead and fixed those with a clear solution. but i was not entirely sure which assets to correct in the context of the page-script-5 repo, but i kept the scope of changes just within the root of `./src` directory (also omitted its subdirectories) - that seemed the most reasonable to me. if more files need to be update please let me know. 

there are a few warnings left, the first two matches are due to hyphenation in a comment and the rest looks all good in context: 

```
concatena
tion
hostandpathname
idrefs
namefrom
skipable
```
